### PR TITLE
the repo is no more on googlemaps-samples

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -85,7 +85,7 @@ This document requires the use of the following pieces of information:
 1.  Obtain the source of the sample apps from GitHub:
 
     ```sh
-    $ git clone https://github.com/googlemaps-samples/last-mile-fleet-solution-samples
+    $ git clone https://github.com/googlemaps/last-mile-fleet-solution-samples.git
     ```
 
 1.  Update the configuration by running the script below. The script will prompt


### PR DESCRIPTION
changed the repo link from https://github.com/googlemaps-samples/last-mile-fleet-solution-samples/ which doesn't work anymore to https://github.com/googlemaps/last-mile-fleet-solution-samples.git

Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
